### PR TITLE
Add the user set network mode to the siminfo table

### DIFF
--- a/src/java/com/android/internal/telephony/SubscriptionController.java
+++ b/src/java/com/android/internal/telephony/SubscriptionController.java
@@ -290,13 +290,16 @@ public class SubscriptionController extends ISub.Stub {
                 SubscriptionManager.MNC));
         // FIXME: consider stick this into database too
         String countryIso = getSubscriptionCountryIso(id);
+        int userNwMode = cursor.getInt(cursor.getColumnIndexOrThrow(
+                SubscriptionManager.USER_NETWORK_MODE));
 
         if (VDBG) {
             String iccIdToPrint = SubscriptionInfo.givePrintableIccid(iccId);
             logd("[getSubInfoRecord] id:" + id + " iccid:" + iccIdToPrint + " simSlotIndex:"
                     + simSlotIndex + " displayName:" + displayName + " nameSource:" + nameSource
                     + " iconTint:" + iconTint + " dataRoaming:" + dataRoaming
-                    + " mcc:" + mcc + " mnc:" + mnc + " countIso:" + countryIso);
+                    + " mcc:" + mcc + " mnc:" + mnc + " countIso:" + countryIso
+                    + " userNwMode:" + userNwMode);
         }
 
         // If line1number has been set to a different number, use it instead.
@@ -305,7 +308,8 @@ public class SubscriptionController extends ISub.Stub {
             number = line1Number;
         }
         return new SubscriptionInfo(id, iccId, simSlotIndex, displayName, carrierName,
-                nameSource, iconTint, number, dataRoaming, iconBitmap, mcc, mnc, countryIso);
+                nameSource, iconTint, number, dataRoaming, iconBitmap, mcc, mnc,
+                countryIso, userNwMode);
     }
 
     /**


### PR DESCRIPTION
* To track what the user set for the particular sub independent
  of the currently set network mode (i.e. PREFERRED_NETWORK_MODE)
* Useful on MSIM where the modem may only support 2G on one of the slots,
  so the preferred network mode (and the NETWORK_MODE column) would
  not always reflect the user desired network mode.

Change-Id: Iab98955ccb3955249f78cc0341d0cfa8eb195775
Ref: CYNGNOS-291